### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 CC=mpicc
 
 # Compilation flags
-CFLAGS?=-O3 -std=gnu99 -I.
+CFLAGS?=-O2 -std=gnu99 -I.
 
 # define any libraries to link into executable:
 LIBS?=-lm

--- a/ms.c
+++ b/ms.c
@@ -198,7 +198,6 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot, struct para
 				free(seglst[seg].ptree) ;
 		}
 		result.tree = treeOutput;
-		printf("%s", treeOutput);
 	}
 
 	if( pars.mp.timeflag ) {
@@ -845,27 +844,23 @@ parens( struct node *ptree, int *descl, int *descr,  int noden)
 	if( descl[noden] == -1 )
 	{
 		sprintf(result,"%d:%5.3lf", noden+1, (ptree+ ((ptree+noden)->abv))->time );
-		//fprintf(stdout, "%d:%5.3lf", noden+1, (ptree+ ((ptree+noden)->abv))->time );
 	}
 	else
 	{
 		sprintf(result, "(");
-		//fprintf(stdout, "(");
 		result = append(result, parens( ptree, descl,descr, descl[noden] ));
 		result = append(result, ",");
-		//fprintf(stdout, ",");
 		result = append(result, parens(ptree, descl, descr, descr[noden] )) ;
 		if( (ptree+noden)->abv == 0 )
 		{
 			result = append(result, ");\n");
-			//fprintf(stdout, ");\n");
 		}
-		else {
+		else
+        {
 			time = (ptree + (ptree+noden)->abv )->time - (ptree+noden)->time ;
 			char* tempString = malloc(9);
 			sprintf(tempString, "):%5.3lf", time );
 			result = append(result, tempString);
-			//fprintf(stdout, "):%5.3lf", time );
 		}
 	}
 	return result;

--- a/mspar.c
+++ b/mspar.c
@@ -312,25 +312,20 @@ char *doPrintWorkerResultHeader(int segsites, double probss, struct params pars,
     if( (segsites > 0 ) || ( pars.mp.theta > 0.0 ) )
     {
         length += 21; // "segsites: " + estimation of segsites digits + CR/LF
-        if (pars.mp.treeflag)
-        {
-            length += strlen(treeOutput);
-        }
+        if (!pars.mp.treeflag)
+            asprintf(&treeOutput, "\n");
+
+        length += strlen(treeOutput);
 
         if( (pars.mp.segsitesin > 0 ) && ( pars.mp.theta > 0.0 ))
-        {
             length += 17; // "prob: " + estimation of probss digits + CR/LF
-        }
     }
     results = malloc(sizeof(char)*length);
 
     sprintf(results, "\n//");
 
     if( (segsites > 0 ) || ( pars.mp.theta > 0.0 ) ) {
-        if( pars.mp.treeflag )
-            sprintf(results, "%s%s", results, treeOutput);
-        else
-            sprintf(results, "%s%s", results, "\n");
+        sprintf(results, "%s%s", results, treeOutput);
 
         if( (pars.mp.segsitesin > 0 ) && ( pars.mp.theta > 0.0 ))
             sprintf(results, "%sprob: %g\n", results, probss);

--- a/mspar.c
+++ b/mspar.c
@@ -27,6 +27,9 @@ void singleNodeProcessing(int howmany, struct params parameters, unsigned int ma
     if (world_rank == 0) // let the "global master" to generate the remainder samples as well
         samples += remainder;
 
+    if (diagnose)
+        fprintf(stderr, "[%d] -> Vamos a generar [%d] samples.\n", world_rank, samples);
+
     char *results = generateSamples(samples, parameters, maxsites, bytes);
     printSamples(results, *bytes);
 }
@@ -221,17 +224,18 @@ char *generateSamples(int samples, struct params parameters, unsigned maxsites, 
     int length;
 
     results = generateSample(parameters, maxsites, &length);
+
     *bytes = length;
 
     int i;
-    for (i = 1; i < samples; ++i) {
+    for (i = 1; i < samples; ++i) { // starts in 1 because a sample was already generated before the for-loop
         sample = generateSample(parameters, maxsites, &length);
 
-        results = realloc(results, *bytes + length + 1);
+        results = realloc(results, *bytes + length + 2);
 
         memcpy(results + *bytes, sample, length);
 
-        *bytes += length + 1;
+        *bytes += length;
         free(sample);
     }
 
@@ -268,6 +272,7 @@ char* generateSample(struct params parameters, unsigned maxsites, int *bytes)
 
     offset = strlen(results);
     *bytes = offset;
+
 
     if(segsites > 0)
     {


### PR DESCRIPTION
Remove duplicate tree output.
Simplify the management of treeoutput when flag is not included.
Fix offset management in sample construction
Use -O2 compilation flag for better performance compared against -O3